### PR TITLE
BUG: forward ssh-agent by default

### DIFF
--- a/ssh/config
+++ b/ssh/config
@@ -7,14 +7,6 @@ Host github
     ForwardX11 no
     PreferredAuthentications=publickey
 
-Host !github
-    ForwardAgent yes
-    Compression yes
-    ForwardX11 yes
-    ForwardX11Trusted yes
-    XAuthLocation /opt/X11/bin/xauth
-    PreferredAuthentications=publickey
-
 Host pslogin
     HostName pslogin.slac.stanford.edu
     # ControlMaster can allow you to multiplex pslogin connections!
@@ -34,7 +26,6 @@ Host pslogin-arch
     LocalForward 8090 recipesrv:80
 
 Host psbuild-rhel7
-    ForwardAgent yes
     HostName psbuild-rhel7-01
     ProxyCommand ssh -XT pslogin nc %h %p
 
@@ -866,3 +857,11 @@ Host xpp-daq-ics
 
 Host xpp-daq-ipmi
     ProxyCommand ssh -XT psbuild-rhel7 nc %h %p
+
+Host !github
+    ForwardAgent yes
+    Compression yes
+    ForwardX11 yes
+    ForwardX11Trusted yes
+    XAuthLocation /opt/X11/bin/xauth
+    PreferredAuthentications=publickey


### PR DESCRIPTION
For some reason the config works as is for Ken, but not for Robert.  Robert needed to forward the ssh-agent to psbuild explicitly. 

We're all a tad confused but this works for now