### PR TITLE
ENH: add helpers with fzf/jq and a try_me script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,22 @@
 # shared-dotfiles
 
-Shared configuration useful for PCDS engineers: "dot" files such as .ssh/config.
+Shared configuration useful for PCDS engineers: "dot" files such as bash
+configuration (.bashrc) and SSH configuration (.ssh/config).
 
 ## How to use these
 
+### Trial run
+
+```bash
+$ ssh psbuild-rhel7
+$ git clone git@github.com:pcdshub/shared-dotfiles dotfiles
+$ cd dotfiles
+$ bash --rcfile try_me.sh
+```
+
 ### Out-of-the-box
+
+To link the scripts here and use them every time when you login:
 
 ```bash
 $ ssh psbuild-rhel7

--- a/bashrc
+++ b/bashrc
@@ -108,6 +108,28 @@ bind "set show-all-if-ambiguous on"
 bind "set mark-symlinked-directories on"
 
 
+# *******************
+# ** Fuzzy finding **
+# *******************
+
+# With this configuration, you can fuzzy find your way through your bash
+# history or files in the current directory.
+#
+# Key bindings:
+#   Ctrl-R: search through your bash history by typing a query
+#   Ctrl-T: search through files in the current directory
+#
+# We leave this enabled by default, but if you prefer the original bash
+# behavior, feel free to comment out - or remove - this section.
+
+_FZF_SHARE_PATH="$_PCDS_CONDA_FOR_UTILS/share/fzf"
+_FZF_COMPLETIONS="$_FZF_SHARE_PATH/shell/completions.bash"
+_FZF_BINDINGS="$_FZF_SHARE_PATH/shell/key-bindings.bash"
+
+[ -f "$_FZF_COMPLETIONS" ] && source "$_FZF_COMPLETIONS";
+[ -f "$_FZF_BINDINGS" ] && source "$_FZF_BINDINGS";
+
+
 # **********************
 # ** History settings **
 # **********************

--- a/bashrc
+++ b/bashrc
@@ -7,6 +7,12 @@
 # ** Prompt and basic settings **
 # *******************************
 
+# Here is where your dotfiles should be located.  Let's set this so
+# we can reuse this later.
+if [ -z "$dotfiles" ]; then
+    export dotfiles="$HOME/dotfiles"
+fi
+
 # The following sets up your prompt to show at least the host
 export PS1='\[\e[0;31m\][\u@\h  \W]\$\[\e[m\] '
 export PROMPT_COMMAND='echo -ne "\033]0;${USER}@${HOSTNAME%%.*}:${PWD/#$HOME/~}\007"'
@@ -33,6 +39,11 @@ export HAPPI_CFG=/cds/group/pcds/pyps/apps/hutch-python/device_config/happi.cfg
 # **************************************************
 # ** External scripts with common useful settings **
 # **************************************************
+
+# Add in the shared-dotfiles provided helpers:
+#  This includes some longer functions which you might not want to see
+#  each time you poke around with your own dotfiles.
+source "$dotfiles/helpers.sh"
 
 # This includes tokens for accessing typhos / confluence resources:
 source /cds/group/pcds/pyps/conda/.tokens/typhos.sh
@@ -204,9 +215,6 @@ shopt -s cdable_vars
 #    $ $repos/pcdsdevices
 #    $ $repos/lightpath
 #
-# Also consider adding:
-#   export dotfiles="$HOME/dotfiles"
-
 
 # ****************************
 # ** Miscellaneous settings **

--- a/helpers.sh
+++ b/helpers.sh
@@ -1,0 +1,112 @@
+#!/bin/bash
+#
+# This file contains some helper scripts for your dotfiles to reuse.
+#
+
+if [ -z "$_PCDS_CONDA_FOR_UTILS" ]; then
+    _PCDS_CONDA_FOR_UTILS=/cds/group/pcds/pyps/conda/py39/envs/pcds-5.3.0/
+fi
+
+# ALL_IOCS_TEXT=/cds/data/iocData/.all_iocs/iocs.txt
+_ALL_IOCS_JSON=/cds/data/iocData/.all_iocs/iocs.json
+
+
+# _helper_pick_directory:
+#   Use a fuzzy finder to pick a directory underneath the provided path.
+#
+#   Usage: _helper_pick_directory [path] [query string]
+_helper_pick_directory() {
+    local new_directory
+    local starting_dir
+    local query_string
+
+    starting_dir=$1
+    shift
+    query_string="$*"
+
+    if [ -z "$starting_dir" ]; then
+        echo "No starting directory was provided" > /dev/stderr
+        return
+    fi
+
+    if [ -n "$query_string" ]; then
+        query_args=("-q" "$query_string")
+    else
+        query_args=()
+    fi
+
+    local fzf
+    fzf=$(_helper_find_fzf)
+    if [ -z "$fzf" ]; then
+        echo "Sorry, fzf was not found." > /dev/stderr
+        return
+    fi
+
+    find "$starting_dir" -maxdepth 1 -type d 2> /dev/null | $fzf +m "${query_args[@]}"
+}
+
+# _helper_cd_under:
+#   CD to a directory underneath the provided one, filtered by fzf
+#
+#   Usage: _helper_cd_under [path] [query string]
+_helper_cd_under() {
+    local new_directory
+    new_directory=$(_helper_pick_directory "$@")
+    if [ -n "$new_directory" ]; then
+        echo "cd \"$new_directory\""
+        history -s "cd \"$new_directory\""
+        cd "$new_directory" || return
+    fi
+}
+
+
+# _helper_find_fzf
+#   Find the JSON query tool, jq, if available.
+_helper_find_jq() {
+    local jq
+    jq=$(command -v jq 2>/dev/null)
+    if [ -z "$jq" ]; then
+        jq="${_PCDS_CONDA_FOR_UTILS}/bin/jq"
+        if [ ! -x "$jq" ]; then
+            jq=""
+        fi
+    fi
+    echo "$jq"
+}
+
+# _helper_find_fzf
+#   Find the fuzzy finder, fzf, if available.
+_helper_find_fzf() {
+    local fzf
+    fzf=$(command -v fzf 2>/dev/null)
+    if [ -z "$fzf" ]; then
+        fzf="${_PCDS_CONDA_FOR_UTILS}/bin/fzf"
+        if [ ! -x "$fzf" ]; then
+            fzf=""
+        fi
+    fi
+    echo "$fzf"
+}
+
+
+# _helper_get_ioc_info
+#   Get IOC information in JSON format.
+#   Usage: _helper_get_ioc_info_json (ioc_name)
+#   Example: _helper_get_ioc_info_json ioc-lfe-motion
+#   Example: _helper_get_ioc_info_json ioc-lfe-motion | jq ".config_file"
+_helper_get_ioc_info_json() {
+    local ioc_name
+    ioc_name=$1
+    if [ -z "$ioc_name" ]; then
+        echo "No IOC specified" > /dev/stderr
+        return
+    fi
+
+    local jq
+    jq=$(_helper_find_jq)
+    if [ -x "$jq" ]; then
+        $jq ".[] | select(.name == \"$ioc_name\")" < $_ALL_IOCS_JSON
+    else
+        echo "Sorry, jq is unavailable" 2>/dev/stderr
+    fi
+}

--- a/try_me.sh
+++ b/try_me.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+echo "To try these dotfiles without installing them, run the following: "
+echo "$ bash --rcfile try_me.sh"
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+export dotfiles="$SCRIPT_DIR"
+
+echo "* Loading the provided bashrc..."
+source "$SCRIPT_DIR/bashrc"
+echo "* Loading the provided bash_functions..."
+source "$SCRIPT_DIR/bash_functions"
+echo "* Loading the provided bash_aliases..."
+source "$SCRIPT_DIR/bash_aliases"

--- a/use_dotfiles.sh
+++ b/use_dotfiles.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-cd $HOME
+cd "$HOME" || exit
 
-if [ ! -d dotfiles ]; then
+if [ ! -d "dotfiles" ]; then
     echo "Did you forget to clone dotfiles into $HOME/dotfiles?" > /dev/stderr
     exit 1;
 fi


### PR DESCRIPTION
* Try these scripts without installing them (it'll mostly work, at least)
   * `bash --rcfile try_me.sh`
* Fuzzy find IOCs (`grep_ioc`)
* Fuzzy find an IOC and then `cd` to its data directory  (`iocdata`)
* Fuzzy find an IOC and then `cd` to its startup directory (`cdioc`)
* Add helpers for jq/fzf to find them in a released pcds-env 
* Enable fzf bindings for ctrl-r and ctrl-t in bash

Closes #5 