### PR TITLE
MNT: set UpdateHostKeys as per github's suggestion

### DIFF
--- a/off_site/ssh/config
+++ b/off_site/ssh/config
@@ -1384,6 +1384,7 @@ Host github.com
     ForwardX11Trusted no
     PreferredAuthentications=publickey
     RequestTTY no
+    UpdateHostKeys yes
 
 Host centos7
     HostName centos7.slac.stanford.edu

--- a/on_site/ssh/config
+++ b/on_site/ssh/config
@@ -14,6 +14,7 @@ Host github.com
     ForwardX11Trusted no
     PreferredAuthentications=publickey
     RequestTTY no
+    UpdateHostKeys yes
 
 Host *
     ForwardAgent yes


### PR DESCRIPTION
https://github.blog/2021-09-01-improving-git-protocol-security-github/#no-more-unauthenticated-git
<img width="791" alt="image" src="https://user-images.githubusercontent.com/5139267/160024162-d7190708-f2d8-4ca2-ba01-42167224c536.png">

Which we discovered after `git://` was disabled on GitHub.