### PR TITLE
REF/ENH: Alternate, easier trial mode + more

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,19 +25,46 @@ following:
 $ ssh psbuild-rhel7
 $ git clone git@github.com:pcdshub/shared-dotfiles dotfiles
 $ cd dotfiles
-$ ./try_me_onsite.sh
+$ ./try_me.sh
 # Then read the instructions in the script output.
 ```
 
-Please note that this only applies to the bash configuration and not the SSH,
-git, vim, and other provided configurations here.
+Please note that this only applies to the bash and vim configuration and not
+the SSH, git, and other provided configurations here.
 
 ### Out-of-the-box
+
+#### Sourcing method
+
+The easiest method to getting just the bash configuration can be to source
+it from your existing "~/.bashrc" script.
+
+Perform the following:
+
+```bash
+$ ssh psbuild-rhel7
+$ cd
+# In your home directory, clone the dotfiles:
+$ git clone git@github.com:pcdshub/shared-dotfiles dotfiles
+```
+
+And then add this line to your bashrc to include the on-site bashrc
+configuration:
+
+```bash
+$ echo 'source $HOME/dotfiles/on_site/bash_all.sh' >> $HOME/.bashrc
+```
+
+#### Installation method
+
+A more permanent solution could be to use just these dotfiles.
 
 To link the scripts here and use them every time when you login:
 
 ```bash
 $ ssh psbuild-rhel7
+$ cd
+# In your home directory, clone the dotfiles:
 $ git clone git@github.com:pcdshub/shared-dotfiles dotfiles
 $ cd dotfiles
 $ bash use_dotfiles.sh

--- a/helpers.sh
+++ b/helpers.sh
@@ -11,9 +11,25 @@ if [ -z "$_PCDS_CONDA_FOR_UTILS" ]; then
     _PCDS_CONDA_FOR_UTILS=/cds/group/pcds/pyps/conda/py39/envs/pcds-5.3.0/
 fi
 
+# shellcheck disable=SC2034
 _ALL_IOCS_TEXT=/cds/data/iocData/.all_iocs/iocs.txt
 _ALL_IOCS_JSON=/cds/data/iocData/.all_iocs/iocs.json
 
+# _helper_cd_verbose
+#  Change directory to the provided path and let the user know about it.
+#  Also adds the path to the user's history.
+#  	  Usage: pythonpathmunge (dirname)
+_helper_cd_verbose() {
+    new_path="$1"
+    if [ -z "$new_path" ]; then
+        return
+    fi
+    cd "$new_path" || return
+    history -s "cd \"$new_path\""
+    echo "Old directory: $OLDPWD"
+    echo "Working directory: $PWD"
+    echo "Tip: use 'cd -' to go back."
+}
 
 # _helper_pick_directory:
 #   Use a fuzzy finder to pick a directory underneath the provided path.
@@ -263,3 +279,4 @@ pythonpathmunge()
 	pathpurge "$to_add"
 	export PYTHONPATH=$to_add:$PYTHONPATH
 }
+

--- a/helpme.md
+++ b/helpme.md
@@ -184,7 +184,7 @@ $ cdioc iocname
 To get to an IOC data directory quickly:
 
 ```bash
-$ iocdata
+$ cdiocdata
 ```
 
 To list all IOCs:
@@ -203,9 +203,9 @@ $ which_ioc_json
 Navigating to hutch-python directories
 --------------------------------------
 
-* ``hutch_config`` hutch configuration directory
-* ``hutchp_dir`` hutch-python configuration directory
-* ``hutchp_logs`` hutch-python log directory
+* ``cdhutchconfig`` hutch configuration directory
+* ``cdhutchp`` hutch-python configuration directory
+* ``cdhutchp_logs`` hutch-python log directory
 
 
 Viewing logs

--- a/on_site/bash_all.sh
+++ b/on_site/bash_all.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+source "$SCRIPT_DIR/bashrc"
+source "$SCRIPT_DIR/bash_functions"
+source "$SCRIPT_DIR/bash_aliases"

--- a/on_site/bash_functions
+++ b/on_site/bash_functions
@@ -175,12 +175,27 @@ hutch_config() {
     cd "/cds/group/pcds/config/$hutch/"
 }
 
+# markdown_view - view GitHub-flavored markdown files in lynx
+#  Usage: markdown_view filename.md
+#  Example: markdown_view helpme.md
+markdown_view() {
+    markdown_file="$1"
+    pandoc="$_PCDS_CONDA_FOR_UTILS/bin/pandoc"
+    lynx=$(command -v lynx 2>/dev/null)
+    if [ -x "$lynx" ]; then
+        echo "Opening $markdown_file with lynx..."
+        exec "${pandoc}" --from gfm --to html "$markdown_file" | "$lynx" -stdin
+    else
+        less "$markdown_file"
+    fi
+}
+
 # helpme
 #   Usage: helpme
 #   Example: helpme
 helpme() {
     # shellcheck disable=SC2154
-    less "$dotfiles/helpme.md"
+    markdown_view "$dotfiles/helpme.md"
 }
 
 # ****************

--- a/on_site/bash_functions
+++ b/on_site/bash_functions
@@ -180,6 +180,11 @@ hutch_config() {
 #  Example: markdown_view helpme.md
 markdown_view() {
     markdown_file="$1"
+    if [ -z "$markdown_file" ]; then
+        echo "Usage: markdown_view filename.md"
+        return
+    fi
+
     pandoc="$_PCDS_CONDA_FOR_UTILS/bin/pandoc"
     lynx=$(command -v lynx 2>/dev/null)
     if [ -x "$lynx" ]; then

--- a/on_site/bash_functions
+++ b/on_site/bash_functions
@@ -73,10 +73,10 @@ which_ioc_json() {
 }
 
 # Go to an IOC data directory (with fuzzy searching).
-#  Usage: iocdata [query]
-#  Example: iocdata
-#  Example: iocdata ioc-xcs
-iocdata() {
+#  Usage: cdiocdata [query]
+#  Example: cdiocdata
+#  Example: cdiocdata ioc-xcs
+cdiocdata() {
     _helper_cd_under /cds/data/iocData "$@"
 }
 
@@ -102,10 +102,7 @@ cdioc() {
     ioc_path=$(dirname "$ioc_startup")
 
     if [ -d "$ioc_path" ]; then
-        cd "$ioc_path" || return
-        history -s "cd \"$ioc_path\""
-        echo "Working directory: $PWD"
-        echo "Tip: use 'cd -' to go back."
+        _helper_cd_verbose "$ioc_path"
     else
         echo "$ioc_path does not exist"
     fi
@@ -136,28 +133,28 @@ ipython_debug_entrypoint() {
     fi
 }
 
-# hutchp_dir - go to the per-hutch hutch-python configuration directory.
-#   Usage: hutchp_dir [hutch_name]
-#   Example: hutchp_dir rix
-hutchp_dir() {
+# cdhutchp - go to the per-hutch hutch-python configuration directory.
+#   Usage: cdhutchp [hutch_name]
+#   Example: cdhutchp rix
+cdhutchp() {
     hutch=$(_helper_maybe_get_hutch "$1")
-    [ "$hutch" == "unknown_hutch" ] && echo "Unknown hutch for $(hostname -s)"; return;
-    cd "/cds/group/pcds/pyps/apps/hutch-python/$hutch/" || return
+    [ "$hutch" == "unknown_hutch" ] && echo "Unknown hutch for $(hostname -s). Please specify a hutch." && return
+    _helper_cd_verbose "/cds/group/pcds/pyps/apps/hutch-python/$hutch/"
 }
 
-# hutchp_logs - go to the per-hutch hutch-python log directory.
-#   Usage: hutchp_logs (hutch_name)
-#   Example: hutchp_logs rix
-hutchp_logs() {
+# cdhutchp_logs - go to the per-hutch hutch-python log directory.
+#   Usage: cdhutchp_logs (hutch_name)
+#   Example: cdhutchp_logs rix
+cdhutchp_logs() {
     hutch=$(_helper_maybe_get_hutch "$1")
-    [ "$hutch" == "unknown_hutch" ] && echo "Unknown hutch for $(hostname -s)"; return;
+    [ "$hutch" == "unknown_hutch" ] && echo "Unknown hutch for $(hostname -s). Please specify a hutch." && return
     log_path="/cds/group/pcds/pyps/apps/hutch-python/${hutch}/logs"
     current_year=$(date -u +"%Y_")
     current_month=$(date -u +"%Y_%m")
     date_path="${log_path}/${current_month}"
     if [ -d "$date_path" ]; then
         echo "$date_path"
-        cd "$date_path" || return
+        _helper_cd_verbose "$date_path"
     else
         echo "$log_path"
         # shellcheck disable=SC2164
@@ -165,14 +162,13 @@ hutchp_logs() {
     fi
 }
 
-# hutch_config - go to the per-hutch configuration directory.
-#   Usage: hutch_config (hutch_name)
-#   Example: hutch_config rix
-hutch_config() {
+# cdhutchconfig - go to the per-hutch configuration directory.
+#   Usage: cdhutchconfig (hutch_name)
+#   Example: cdhutchconfig rix
+cdhutchconfig() {
     hutch=$(_helper_maybe_get_hutch "$1")
-    [ "$hutch" == "unknown_hutch" ] && echo "Unknown hutch for $(hostname -s)"; return;
-    # shellcheck disable=SC2164
-    cd "/cds/group/pcds/config/$hutch/"
+    [ "$hutch" == "unknown_hutch" ] && echo "Unknown hutch for $(hostname -s). Please specify a hutch." && return
+    _helper_cd_verbose "/cds/group/pcds/config/$hutch/"
 }
 
 # markdown_view - view GitHub-flavored markdown files in lynx

--- a/try_me.sh
+++ b/try_me.sh
@@ -3,10 +3,10 @@
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 export dotfiles="$SCRIPT_DIR"
 
-if [ "$_SHARED_DOTFILE_TRIAL" == "" ]; then
+if [ "$_SHARED_DOTFILE_SITE" == "" ]; then
     cd "$SCRIPT_DIR" || (echo "Failed to cd to shared-dotfiles." && exit 1)
-    echo "Running $SCRIPT_DIR"
-    exec env -i - _SHARED_DOTFILE_TRIAL=1 \
+    on_or_off="${1-on}"
+    exec env -i - _SHARED_DOTFILE_SITE="${on_or_off}" \
             USER="$USER" \
             TERM="$TERM" \
             HOME="$HOME" \
@@ -15,16 +15,16 @@ if [ "$_SHARED_DOTFILE_TRIAL" == "" ]; then
             SSH_AUTH_SOCK="$SSH_AUTH_SOCK" \
             DISPLAY="$DISPLAY" \
             dotfiles="$dotfiles" \
-        bash --rcfile "try_me_onsite.sh" --noprofile
+        bash --rcfile "try_me.sh" --noprofile
     exit
 fi
 
 echo "* Loading the provided bashrc..."
-source "$SCRIPT_DIR/on_site/bashrc"
+source "$SCRIPT_DIR/${_SHARED_DOTFILE_SITE}_site/bashrc"
 echo "* Loading the provided bash_functions..."
-source "$SCRIPT_DIR/on_site/bash_functions"
+source "$SCRIPT_DIR/${_SHARED_DOTFILE_SITE}_site/bash_functions"
 echo "* Loading the provided bash_aliases..."
-source "$SCRIPT_DIR/on_site/bash_aliases"
+source "$SCRIPT_DIR/${_SHARED_DOTFILE_SITE}_site/bash_aliases"
 
 # Custom settings just for "tryme" mode:
 export PS1="[dotfiles-tryme] $PS1"
@@ -35,7 +35,9 @@ alias vim='vim -u "$dotfiles/vimrc"'
 alias view='view -u "$dotfiles/vimrc"'
 
 echo "
-Loaded the shared dotfiles.
+Introduction
+============
+
 For a reminder on what is provided with this package, take a look at
 'helpme.md' in the editor of your choice or type:
 
@@ -44,12 +46,17 @@ For a reminder on what is provided with this package, take a look at
 When done testing, type 'exit' to return to your usual bash prompt.
 
 This trial mode includes the following shared-dotfiles settings:
-    * On-site bash settings (bashrc, bash_functions, and bash_aliases)
+    * bash settings (bashrc, bash_functions, and bash_aliases)
     * vim settings (vimrc)
+    * A regular installation will not include a '[dotfiles-tryme]' prompt.
 
 This trial mode DOES NOT automatically include the following shared-dotfiles settings:
     * SSH configuration
     * git configuration
     * conda settings
     * tmux settings
+
+------------------------------------------------------------------------------------
+Beginning a trial shared dotfiles bash session in ${_SHARED_DOTFILE_SITE}-site mode.
+------------------------------------------------------------------------------------
 "

--- a/try_me_onsite.sh
+++ b/try_me_onsite.sh
@@ -1,25 +1,23 @@
 #!/bin/bash
 
-
-if [ "$0" != "bash" ]; then
-    echo "To try the bash configuration provided here, run the following:"
-    echo "$ bash --rcfile try_me_onsite.sh"
-    echo
-    echo "Please note that this does not include the ssh configuration, vim configuration,"
-    echo "or anything beyond the bash settings."
-    echo
-    echo "If you find your existing settings are getting in the way of trying shared-dotfiles"
-    echo "you can start a new bash session that is isolated from your configuration by way of "
-    echo "the following:"
-    echo
-    # shellcheck disable=SC2016
-    echo '$ env -i - USER=$USER TERM=$TERM HOME=$HOME XDG_SESSION_ID=$XDG_SESSION_ID XDG_RUNTIME_DIR=$XDG_RUNTIME_DIR SSH_AUTH_SOCK=$SSH_AUTH_SOCK DISPLAY=$DISPLAY bash --rcfile try_me_onsite.sh --noprofile'
-    exit 1;
-fi
-
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
-
 export dotfiles="$SCRIPT_DIR"
+
+if [ "$_SHARED_DOTFILE_TRIAL" == "" ]; then
+    cd "$SCRIPT_DIR" || (echo "Failed to cd to shared-dotfiles." && exit 1)
+    echo "Running $SCRIPT_DIR"
+    exec env -i - _SHARED_DOTFILE_TRIAL=1 \
+            USER="$USER" \
+            TERM="$TERM" \
+            HOME="$HOME" \
+            XDG_SESSION_ID="$XDG_SESSION_ID" \
+            XDG_RUNTIME_DIR="$XDG_RUNTIME_DIR" \
+            SSH_AUTH_SOCK="$SSH_AUTH_SOCK" \
+            DISPLAY="$DISPLAY" \
+            dotfiles="$dotfiles" \
+        bash --rcfile "try_me_onsite.sh" --noprofile
+    exit
+fi
 
 echo "* Loading the provided bashrc..."
 source "$SCRIPT_DIR/on_site/bashrc"
@@ -28,4 +26,20 @@ source "$SCRIPT_DIR/on_site/bash_functions"
 echo "* Loading the provided bash_aliases..."
 source "$SCRIPT_DIR/on_site/bash_aliases"
 
+# Custom settings just for "tryme" mode:
 export PS1="[dotfiles-tryme] $PS1"
+
+# Alias some tools to allow for the configuration to be used
+alias vi='vi -u "$dotfiles/vimrc"'
+alias vim='vim -u "$dotfiles/vimrc"'
+alias view='view -u "$dotfiles/vimrc"'
+
+echo "
+Loaded the shared dotfiles.
+For a reminder on what is provided with this package, take a look at
+'helpme.md' in the editor of your choice or type:
+
+    $ helpme
+
+When done testing, type 'exit' to return to your usual bash prompt.
+"

--- a/try_me_onsite.sh
+++ b/try_me_onsite.sh
@@ -42,4 +42,14 @@ For a reminder on what is provided with this package, take a look at
     $ helpme
 
 When done testing, type 'exit' to return to your usual bash prompt.
+
+This trial mode includes the following shared-dotfiles settings:
+    * On-site bash settings (bashrc, bash_functions, and bash_aliases)
+    * vim settings (vimrc)
+
+This trial mode DOES NOT automatically include the following shared-dotfiles settings:
+    * SSH configuration
+    * git configuration
+    * conda settings
+    * tmux settings
 "


### PR DESCRIPTION
* Trial mode now only requires: `./try_me.sh` (defaults to on-site trial; `./try_me.sh off` should work for the off-site config)
* Renamed navigation tools to be "cd(something)"
* Rendering the "helpme" text using pandoc->lynx, if available
* Add `markdown_view` utility
* Add verbose 'cd' helper and used it in a few places