### PR TITLE
ENH: disable ctrl-s/ctrl-q to avoid confusion; add which_command

### DIFF
--- a/helpers.sh
+++ b/helpers.sh
@@ -20,6 +20,7 @@ _ALL_IOCS_JSON=/cds/data/iocData/.all_iocs/iocs.json
 #  Also adds the path to the user's history.
 #  	  Usage: pythonpathmunge (dirname)
 _helper_cd_verbose() {
+    local new_path
     new_path="$1"
     if [ -z "$new_path" ]; then
         return
@@ -80,7 +81,7 @@ _helper_cd_under() {
 }
 
 
-# _helper_find_fzf
+# _helper_find_jq
 #   Find the JSON query tool, jq, if available.
 _helper_find_jq() {
     local jq

--- a/helpme.md
+++ b/helpme.md
@@ -59,7 +59,7 @@ have before running them.
 * ``pydev_env`` Source this file to activate a development environment based on
   the latest shared environment and on past calls to pydev_register``.
 * ``pydev_register``  Use this script to register development packages so
-  that they will be available when you source pydev_env 
+  that they will be available when you source pydev_env
 * ``pyps-deploy`` Sets up a pyps/apps deployment for a particular github python
   package.
 * ``questionnaire_tools`` tools for interacting with the questionnaire.
@@ -69,9 +69,9 @@ have before running them.
 * ``stopami`` stop the AMI session.
 * ``stopdaq`` stop the DAQ.
 * ``takepeds`` takes a run with dark images for use in pedestals, and posts to
-  the elog. 
+  the elog.
 * ``wheredaq`` discover what host is running the daq in the current hutch, if
-  any. 
+  any.
 * ``wherepsana`` checks where we have shared memory servers for psana running
   and could run psana jobs.
 
@@ -128,6 +128,24 @@ Screens
    - netconfig
    - digiconfig
    - psipmi
+
+
+Other commands
+--------------
+
+There are a lot of commands available in your environment.
+
+To see a list of all of them and where they come from, type:
+
+```bash
+$ which_command
+```
+
+Consider piping that into fzf to find the command you are looking for:
+
+```bash
+$ which_command | fzf
+```
 
 Navigation
 ==========
@@ -231,7 +249,7 @@ Shared filesystems
 Python environments
 -------------------
 
-To access our deployed conda environments, see: 
+To access our deployed conda environments, see:
 https://confluence.slac.stanford.edu/display/PCDS/PCDS+Conda+Python+Environments
 
 Generally, you should only need to run the following on a machine like
@@ -248,7 +266,7 @@ Happi configuration
 -------------------
 
 HAPPI_CFG is set automatically in our Python environment scripts. We store that
-configuration in 
+configuration in
 
 ``/cds/group/pcds/pyps/apps/hutch-python/device_config``
 
@@ -260,7 +278,7 @@ Hutch-python configuration paths
 See [Hutch Python
 Seminar](https://confluence.slac.stanford.edu/display/PCDS/Hutch+Python+Seminar)
 for more details.  You must be added to the relevant instrument group
-(ps-<hutch>, e.g. ps-xpp) for write access to these files 
+(ps-<hutch>, e.g. ps-xpp) for write access to these files
 
 For a given hutch, e.g., `xpp`:
 

--- a/on_site/bash_functions
+++ b/on_site/bash_functions
@@ -191,9 +191,26 @@ markdown_view() {
     fi
 }
 
+# which_command - show all commands and where they come from.
+#   Note that this can take a while to list everything.  Consider
+#   using it with grep or fzf to find what you're looking for.
+#  Usage: which_command
+#  Example: which_command | fzf
+which_command() {
+    local cmd
+    local location
+    for cmd in $(compgen -c | sort | uniq); do
+        location=$(which --skip-functions --skip-alias "$cmd" 2> /dev/null)
+        if [ -n "$location" ]; then
+            echo "$cmd ($location)"
+        else
+            echo "$cmd"
+        fi
+    done
+}
+
 # helpme
 #   Usage: helpme
-#   Example: helpme
 helpme() {
     # shellcheck disable=SC2154
     markdown_view "$dotfiles/helpme.md"

--- a/on_site/bashrc
+++ b/on_site/bashrc
@@ -129,8 +129,15 @@ _FZF_SHARE_PATH="$_PCDS_CONDA_FOR_UTILS/share/fzf"
 _FZF_COMPLETIONS="$_FZF_SHARE_PATH/shell/completions.bash"
 _FZF_BINDINGS="$_FZF_SHARE_PATH/shell/key-bindings.bash"
 
-[ -f "$_FZF_COMPLETIONS" ] && source "$_FZF_COMPLETIONS";
-[ -f "$_FZF_BINDINGS" ] && source "$_FZF_BINDINGS";
+_FZF_PATH=$(_helper_find_fzf)
+if [ -n "$_FZF_PATH" ]; then
+    # Add an alias to 'fzf', if available.
+    # shellcheck disable=SC2139
+    alias fzf="$_FZF_PATH"
+fi
+
+[ -f "$_FZF_COMPLETIONS" ] && source "$_FZF_COMPLETIONS"
+[ -f "$_FZF_BINDINGS" ] && source "$_FZF_BINDINGS"
 
 
 # **********************

--- a/on_site/bashrc
+++ b/on_site/bashrc
@@ -275,6 +275,11 @@ PROMPT_DIRTRIM=2
 # E.g. typing !!<space> will replace the !! with your last command
 bind Space:magic-space
 
+# Disable ctrl-s/ctrl-q - these can cause real confusion.
+stty stop ''
+stty start ''
+stty -ixon
+stty -ixoff
 
 # ***************
 # ** Now what? **

--- a/on_site/bashrc
+++ b/on_site/bashrc
@@ -129,12 +129,7 @@ _FZF_SHARE_PATH="$_PCDS_CONDA_FOR_UTILS/share/fzf"
 _FZF_COMPLETIONS="$_FZF_SHARE_PATH/shell/completions.bash"
 _FZF_BINDINGS="$_FZF_SHARE_PATH/shell/key-bindings.bash"
 
-_FZF_PATH=$(_helper_find_fzf)
-if [ -n "$_FZF_PATH" ]; then
-    # Add an alias to 'fzf', if available.
-    # shellcheck disable=SC2139
-    alias fzf="$_FZF_PATH"
-fi
+pathmunge "/cds/group/pcds/pyps/apps/fzf/bin/"
 
 [ -f "$_FZF_COMPLETIONS" ] && source "$_FZF_COMPLETIONS"
 [ -f "$_FZF_BINDINGS" ] && source "$_FZF_BINDINGS"


### PR DESCRIPTION
* Disable ctrl-s / ctrl-q
    * If you've ever done this by accident, it can be very confusing
* Add `which_command` and documentation on it
* Ensure 'fzf' is accessible, even if not in $PATH