### PR TITLE
ENH: add pcds-tag channel as a backup

### DIFF
--- a/condarc
+++ b/condarc
@@ -2,5 +2,6 @@ show_channel_urls: true
 
 channels:
 - conda-forge
+- pcds-tag
 
 channel_priority: strict


### PR DESCRIPTION
A small handful of our builds are not on conda forge, so this is a good addition to the on-site config.
With strict repo priority, this will not be used unless something is completely missing from conda-forge.