### PR TITLE
MAINT: ignore vim undo files and emacs backups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.sw[op]
+*~
 ssh/id_*
 ssh/authorized_keys
 ssh/known_hosts


### PR DESCRIPTION
The vim config from shared-dotfiles creates .un~ undo files. Let's ignore them in the dotfiles repo, and help out the emacs folk while we're at it.