### PR TITLE
ENH: only use psproxy when not on psbuild

### DIFF
--- a/on_site/ssh/config
+++ b/on_site/ssh/config
@@ -5,9 +5,11 @@
 #
 # This could be called an "on-site" configuration.
 
+Match host github.com exec "hostname | grep -v psbuild"
+    ProxyJump psproxy.pcdsn
+
 Host github.com
     HostName github.com
-    ProxyJump psproxy.pcdsn
     User git
     ForwardAgent no
     ForwardX11 no

--- a/on_site/ssh/config
+++ b/on_site/ssh/config
@@ -5,7 +5,7 @@
 #
 # This could be called an "on-site" configuration.
 
-Match host github.com exec "hostname | grep -v psbuild"
+Match host github.com exec "echo ${http_proxy} | grep psproxy"
     ProxyJump psproxy.pcdsn
 
 Host github.com


### PR DESCRIPTION
psproxy is great, but psbuild already has an internet connection.

Use the ssh config match syntax to check if we're on psbuild, and only use the proxy jump if we're not.