### PR TITLE
FIX: _fzf_completions path incorrect

### DIFF
--- a/on_site/bashrc
+++ b/on_site/bashrc
@@ -126,7 +126,7 @@ bind "set mark-symlinked-directories on"
 # behavior, feel free to comment out - or remove - this section.
 
 _FZF_SHARE_PATH="$_PCDS_CONDA_FOR_UTILS/share/fzf"
-_FZF_COMPLETIONS="$_FZF_SHARE_PATH/shell/completions.bash"
+_FZF_COMPLETIONS="$_FZF_SHARE_PATH/shell/completion.bash"
 _FZF_BINDINGS="$_FZF_SHARE_PATH/shell/key-bindings.bash"
 
 pathmunge "/cds/group/pcds/pyps/apps/fzf/bin/"


### PR DESCRIPTION
Simple typo - oops!

After this, with `pcds_conda` sourced, things like `happi search **[tab]` should allow for fuzzy finding.