### PR TITLE
FIX: bash_all.sh only when login shell in use

### DIFF
--- a/on_site/bash_all.sh
+++ b/on_site/bash_all.sh
@@ -8,7 +8,8 @@ fi
 
 if [ ! -f "$ON_SITE/bashrc" ]; then
     echo "Unable to find the dotfiles script directory. Check your installation." >/dev/stderr
-else
+elif [ -n "$PS1" ]; then
+    # Source all scripts when using an interactive login shell
     source "$ON_SITE/bashrc"
     source "$ON_SITE/bash_functions"
     source "$ON_SITE/bash_aliases"

--- a/on_site/bash_all.sh
+++ b/on_site/bash_all.sh
@@ -8,7 +8,7 @@ fi
 
 if [ ! -f "$ON_SITE/bashrc" ]; then
     echo "Unable to find the dotfiles script directory. Check your installation." >/dev/stderr
-elif [ -n "$PS1" ]; then
+elif [[ "$-" =~ i ]]; then
     # Source all scripts when using an interactive login shell
     source "$ON_SITE/bashrc"
     source "$ON_SITE/bash_functions"


### PR DESCRIPTION
Closes #41 

I'm unable to reproduce the original issue separately. We should test this on the reporter's account to see if this closes it prior to merging.

Reference for the bash options in `$-`:
* https://tldp.org/LDP/abs/html/options.html
* `i` is the "interactive" option which is only present on login shells