### PR TITLE
ENH: basic afs token notification

### DIFF
--- a/helpers.sh
+++ b/helpers.sh
@@ -246,6 +246,22 @@ _helper_readlink() {
 }
 
 
+# _helper_check_afs_token
+#   Check if you have a valid AFS token.
+#   Usage: _helper_check_afs_token
+_helper_check_afs_token() {
+    klist | grep -e "afs/" &>/dev/null
+}
+
+
+# _helper_check_afs_token
+#   Check if you have a valid AFS token.
+#   Usage: _helper_check_afs_token
+_helper_afs_token_valid() {
+    (_helper_check_afs_token && echo "OK") || echo "Run aklog!"
+}
+
+
 # pathpurge
 #  Remove a path from ${PATH}
 #  	  Usage: pathpurge (dirname) [dirname ...]

--- a/on_site/bashrc
+++ b/on_site/bashrc
@@ -14,7 +14,7 @@ if [ -z "$dotfiles" ]; then
 fi
 
 # The following sets up your prompt to show at least the host
-export PS1='\[\e[0;31m\][\u@\h  \W]\$\[\e[m\] '
+export PS1='\[\e[0;31m\] {AFS:$(_helper_afs_token_valid 2>/dev/null)} [\u@\h  \W]\$\[\e[m\] '
 export PROMPT_COMMAND='echo -ne "\033]0;${USER}@${HOSTNAME%%.*}:${PWD/#$HOME/~}\007"'
 
 # Your default editor will be set to vim.


### PR DESCRIPTION
Closes #44 

```
(base)  {AFS:OK} [klauer@psbuild-rhel7-01  ~]$ kdestroy
(base)  {AFS:Run aklog!} [klauer@psbuild-rhel7-01  ~]$
(base)  {AFS:Run aklog!} [klauer@psbuild-rhel7-01  ~]$ kinit && aklog -d
...
(base)  {AFS:OK} [klauer@psbuild-rhel7-01  ~]$ git diff
```

I don't much like the display/formatting. Maybe the OK state shouldn't show anything.