### PR TITLE
REF/ENH: sshcd - make destination path relative to user home when under $HOME/

### DIFF
--- a/off_site/bash_functions
+++ b/off_site/bash_functions
@@ -18,9 +18,15 @@ sshcd() {
     host=$1;
     shift;
     command="$*";
+    path="$PWD"
+
+    if [[ "$path" =~ $HOME/.* ]]; then
+      path=${path#"$HOME/"}
+      echo 'Adjusting path for HOME:' "$path"
+    fi
+
     ssh -t "$host" "
-        cd '${PWD}'
-        echo 'Current working directory: $PWD'
+        cd '$path'
         ${command}
         bash
     ";
@@ -44,8 +50,8 @@ git_setup_fork() {
     echo "${usage}"
     return
   fi
-  REPO=`basename "${1}"`
-  UPSTREAM=`dirname "${1}"`
+  REPO=$(basename "${1}")
+  UPSTREAM=$(dirname "${1}")
   git clone --origin "${GITHUB_ORIGIN:-origin}" "git@github.com:${GITHUB_USERNAME:-${USER}}/${REPO}.git"
   git -C "${REPO}" remote add "${GITHUB_UPSTREAM:-upstream}" "git@github.com:${UPSTREAM}/${REPO}.git"
 }


### PR DESCRIPTION
## Context

A minor fix/addition for `sshcd`:
If the current directory is under `$HOME/`, make the path relative when ssh'ing to the destination.

### Why?

This can help in scenarios where the user's home directory is mounted differently on different hosts.
For me, I keep the same directory structure on my mac laptop, and `sshcd` from `/Users/klauer/Repos/shared-dotfiles` would take me to psbuild `/cds/home/k/klauer/Repos/shared-dotfiles` with this PR.

## Unrelated fix

`shellcheck` was unhappy about backticks for `git_setup_fork`. I changed them to the "modern" `$()` as recommended.