### PR TITLE
REF: suggest users defy git safety warnings and be insecure

### DIFF
--- a/gitconfig
+++ b/gitconfig
@@ -44,5 +44,8 @@
 [pull]
     ff = only
 
+[safe]
+    directory = *
+
 [svn]
     authorsfile=/afs/slac/g/cd/swe/git/repos/package/epics/modules/authors.txt


### PR DESCRIPTION
## Context

New functionality in `git` makes it such that `.git` directories owned by others are regarded as potential security issues and specifically require you to mark them as safe.

`git` commands on various repositories in our shared filesystem are often owned by others in our group (and some that no longer even work with us).

## Fix

On one hand, the git feature is correct to not execute arbitrary code when interacting with another user's git repository.
On the other hand, the safety feature breaks a number of tools that we use and are considering using (versioneer being our primary example, and I just ran into epics-sumo failing with it, ...).

Figuring out all of the directories where we have repositories is probably doable (using wildcards, too), but users will still run into this with non-standard directories.

I have mixed feelings about this one, but I think the least problematic solution for us will be to disable the feature entirely.  That's what this PR does.

## Future?

If in the future, `git` offers the possibility of marking specific users or specific groups as trusted (e.g., we could set `ps-pcds` as a trusted group), perhaps we could go that route.