### PR TITLE
ENH: add whichp

### DIFF
--- a/on_site/bash_aliases
+++ b/on_site/bash_aliases
@@ -73,6 +73,28 @@ hpy3() {
 }
 
 
+# whichp library_name
+#   Determine where your Python library will be imported from. If you use
+#   ``import package_name``, use ``whichp package_name``.
+whichp ()
+{
+  echo "Python: $(which python)"
+  library="$1"
+  if [ -z "$library" ]; then
+    echo "Usage: whichp (library)" >&2
+    return
+  fi
+
+  python -c "
+import os
+import ${library}
+print(f'${library} is from: {${library}.__file__}')
+print(f'${library} version is', getattr(${library}, '__version__', 'unknown'))
+print(f'cd {os.path.dirname(${library}.__file__)}')
+"
+}
+
+
 # ****************
 # ** General    **
 # ****************

--- a/on_site/bash_aliases
+++ b/on_site/bash_aliases
@@ -73,28 +73,6 @@ hpy3() {
 }
 
 
-# whichp library_name
-#   Determine where your Python library will be imported from. If you use
-#   ``import package_name``, use ``whichp package_name``.
-whichp ()
-{
-  echo "Python: $(which python)"
-  library="$1"
-  if [ -z "$library" ]; then
-    echo "Usage: whichp (library)" >&2
-    return
-  fi
-
-  python -c "
-import os
-import ${library}
-print(f'${library} is from: {${library}.__file__}')
-print(f'${library} version is', getattr(${library}, '__version__', 'unknown'))
-print(f'cd {os.path.dirname(${library}.__file__)}')
-"
-}
-
-
 # ****************
 # ** General    **
 # ****************

--- a/on_site/bash_functions
+++ b/on_site/bash_functions
@@ -172,6 +172,28 @@ ipython_debug_entrypoint() {
     fi
 }
 
+# whichp library_name
+#   Determine where your Python library will be imported from. If you use
+#   ``import package_name``, use ``whichp package_name``.
+whichp ()
+{
+  echo "Python: $(which python)"
+  library="$1"
+  if [ -z "$library" ]; then
+    echo "Usage: whichp (library)" >&2
+    return
+  fi
+
+  python -c "
+import os
+import ${library}
+print(f'${library} is from: {${library}.__file__}')
+print(f'${library} version is', getattr(${library}, '__version__', 'unknown'))
+print(f'cd {os.path.dirname(${library}.__file__)}')
+"
+}
+
+
 # cdhutchp - go to the per-hutch hutch-python configuration directory.
 #   Usage: cdhutchp [hutch_name]
 #   Example: cdhutchp rix


### PR DESCRIPTION
 Determine where your Python library will be imported from. If you use ``import package_name``, use ``whichp package_name``.

Closes #51

Sample output:

```
(lucid) PC98125:shared-dotfiles klauer$ whichp pydm
Python: /Users/klauer/mc/envs/lucid/bin/python
pydm is from: /Users/klauer/Repos/pydm/pydm/__init__.py
pydm version is v1.18.2+0.g563820ab.dirty
cd /Users/klauer/Repos/pydm/pydm
```