### PR TITLE
ENH: ioclog fzf picker

### DIFF
--- a/on_site/bash_functions
+++ b/on_site/bash_functions
@@ -71,13 +71,24 @@ git_sync_upstream() {
 
 
 # Watch a log file from a given IOC.
-#  Usage: ioclog (iocname)
+#  Usage: ioclog [iocname]
 #  Example: ioclog ioc-xpp-gige-las01
 #  Example: ioclog ioc-xpp-*-las01
 ioclog() {
+  if [ $# -ge 1 ]; then
     # shellcheck disable=SC2086 # allow for globbing of IOC names
     tail -n 50 -f /cds/data/iocData/$1/iocInfo/ioc.log
+  else
+    local ioc_dir
+    ioc_dir=$(_helper_pick_directory /cds/data/iocData)
+    if [ -z "$ioc_dir" ]; then
+      return
+    fi
+    history -s "ioclog $(basename "${ioc_dir}")"
+    tail -n 50 -f "${ioc_dir}/iocInfo/ioc.log"
+  fi
 }
+
 
 # Find a currently-deployed IOC with a bit more details:
 #  Usage: which_ioc [iocname]


### PR DESCRIPTION
```bash
$ ioclog
  /cds/data/iocData/ioc-lm1k4-ejx-ell-05
  /cds/data/iocData/ioc-tmo-plv-pdu-05
  /cds/data/iocData/ioc-tst-ipimb-05
  /cds/data/iocData/ioc-las-gige-mods-comp05
  /cds/data/iocData/ioc-mec-las-gige03-5
  /cds/data/iocData/ioc-cxi-mmc-pp30-05
  /cds/data/iocData/ioc-lm1k4-atm-gige-05
  /cds/data/iocData/ioc-mec-lpl-lco-05
> /cds/data/iocData/ioc-mfx-gige-05
  9/2500
> cam05

(hit enter, tails log of mfx-gige-05, and adds the following to bash history)
$ ioclog ioc-mfx-gige-05
```