### PR TITLE
ENH: add ssh config for tcbsd plc logins

### DIFF
--- a/on_site/ssh/config
+++ b/on_site/ssh/config
@@ -18,6 +18,13 @@ Host github.com
     RequestTTY no
     UpdateHostKeys yes
 
+Host plc-*
+    ForwardAgent no
+    ForwardX11 no
+    ForwardX11Trusted no
+    PreferredAuthentications=publickey,keyboard-interactive
+    User Administrator
+
 Host *
     ForwardAgent yes
     ForwardX11 yes


### PR DESCRIPTION
The TwinCAT BSD PLCs sshd processes accept two authentication methods by default: "publickey" and "keyboard-interactive". For first login you cannot do "publickey" because it requires some setup, while "keyboard-interactive" is precluded by the `Host *` config in this file, which is expecting "password" authentication as the fallback.

The simplest fix is to add an entry for plc login here that enables the "keyboard-interactive" logins for plc hosts.
While we're here, I've hard-coded the username for these logins to be "Administrator".

This should be forward-compatible with whatever we end up deploying for PLC login security.