### PR TITLE
MAINT: don't mess with plc ssh key configs, avoid Administrator account

### DIFF
--- a/on_site/ssh/config
+++ b/on_site/ssh/config
@@ -23,7 +23,7 @@ Host plc-*
     ForwardX11 no
     ForwardX11Trusted no
     PreferredAuthentications=keyboard-interactive
-    User Administrator
+    User ecs-user
 
 Host *
     ForwardAgent yes

--- a/on_site/ssh/config
+++ b/on_site/ssh/config
@@ -22,7 +22,7 @@ Host plc-*
     ForwardAgent no
     ForwardX11 no
     ForwardX11Trusted no
-    PreferredAuthentications=publickey,keyboard-interactive
+    PreferredAuthentications=keyboard-interactive
     User Administrator
 
 Host *


### PR DESCRIPTION
# SSH Keys

While working on https://github.com/pcdshub/twincat-bsd-ansible/pull/14 I realized that having the `publickey` option in the ssh config here means that:

- When logging into a plc, you can be first prompted to unlock your public key
- Your public key doesn't work anyway- we're not going around adding personal keys to every plc

Procedurally, doing it like this (after the edit) requires you to have access to the admin password, which seems in line with the procedure we want people to use for other protected systems like the switches etc.

Alternatively, we could do plc auth by having everyone send their public key to every plc, but that _feels_ wrong.

# Non-admin user

The other change here is to make it so you log in as a non-admin user by default. This means you need to opt-in as the Administrator user by doing e.g. `ssh Administrator@plc-tst-bsd2`, and if you simply `ssh plc-tst-bsd2` you will log in as `ecs-user` instead.