### PR TITLE
MNT: add psbuild-rocky9 as an available host

### DIFF
--- a/off_site/ssh/config
+++ b/off_site/ssh/config
@@ -46,6 +46,10 @@ Host psbuild-rhel7
     HostName psbuild-rhel7-01
     ProxyJump %r@${PS_JUMP_HOST=s3dflogin}
 
+Host psbuild-rocky9
+    HostName psbuild-rocky9
+    ProxyJump %r@${PS_JUMP_HOST=s3dflogin}
+
 Host psdev
     HostName psdev
     ProxyJump %r@${PS_JUMP_HOST=s3dflogin}


### PR DESCRIPTION
As the title states. 

It came to our attention that rocky9 wasn't included in these dotfiles.  In general these haven't been updated in a while.